### PR TITLE
Make sure we give the list of categories to the ConsentCategoryProvider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build
 .idea
 lib/build
 local.properties
+.DS_Store

--- a/testapp/src/main/java/com/segment/analytics/destinations/mydestination/testapp/MainApplication.kt
+++ b/testapp/src/main/java/com/segment/analytics/destinations/mydestination/testapp/MainApplication.kt
@@ -54,6 +54,7 @@ class MainApplication: Application() {
         val consentPlugin = ConsentManager(store, consentCategoryProvider)
 
         analytics.add(consentPlugin)
+        consentPlugin.start()
     }
 
 


### PR DESCRIPTION
Fix issue related to not setting categories for the ConsentCategoryProvider.


Before:
<img width="654" alt="Screenshot 2024-06-05 at 6 40 49 PM" src="https://github.com/segment-integrations/analytics-kotlin-consent/assets/8451149/6098dfef-b953-4e9f-aed3-1fae2e94654a">

After:
<img width="596" alt="Screenshot 2024-06-05 at 6 38 23 PM" src="https://github.com/segment-integrations/analytics-kotlin-consent/assets/8451149/8eb56a23-d73c-4000-aa42-d92203698107">
